### PR TITLE
feat: add profile fallback mechanism and refactor config profiles

### DIFF
--- a/audio2face/apis/streaming_audio2face_v1.py
+++ b/audio2face/apis/streaming_audio2face_v1.py
@@ -313,11 +313,23 @@ class StreamingAudio2FaceV1(Super):
         self.request_space[chunk_end.request_id]['last_update_time'] = cur_time
         old_pcm_bytes = \
             self.request_space[chunk_end.request_id]['pcm_bytes']
+        profile_name = \
+            self.request_space[chunk_end.request_id]['profile_name']
+        if profile_name in self.profiles:
+            postprocess_names = self.profiles[profile_name]
+        else:
+            if len(self.profiles) == 0:
+                msg = 'No profiles found, cannot ' +\
+                    'generate facial expression animation.'
+                self.logger.error(msg)
+                raise ValueError(msg)
+            default_key = next(iter(self.profiles))
+            postprocess_names = self.profiles[default_key]
+            self.logger.warning(
+                f'Profile {profile_name} not found, ' +
+                f'using default profile {default_key}')
         if len(old_pcm_bytes) > 0:
             loop = asyncio.get_event_loop()
-            profile_name = \
-                self.request_space[chunk_end.request_id]['profile_name']
-            postprocess_names = self.profiles[profile_name]
             offset_name = \
                 self.request_space[chunk_end.request_id]['offset_name']
             last_split_time = \
@@ -380,9 +392,6 @@ class StreamingAudio2FaceV1(Super):
             self.logger.warning(
                 f'Request {chunk_end.request_id} at end has no unprocessed audio data.')
         await self.request_space[chunk_end.request_id]['callback'](None)
-        profile_name = \
-            self.request_space[chunk_end.request_id]['profile_name']
-        postprocess_names = self.profiles[profile_name]
         for postprocess_name in postprocess_names:
             self.postprocessors[postprocess_name].clean_stream(chunk_end.request_id)
         self.request_space.pop(chunk_end.request_id)

--- a/audio2face/apis/streaming_audio2face_v1.py
+++ b/audio2face/apis/streaming_audio2face_v1.py
@@ -215,7 +215,19 @@ class StreamingAudio2FaceV1(Super):
             offset_name = chunk_body.offset_name
             profile_name = \
                 self.request_space[chunk_body.request_id]['profile_name']
-            postprocess_names = self.profiles[profile_name]
+            if profile_name in self.profiles:
+                postprocess_names = self.profiles[profile_name]
+            else:
+                if len(self.profiles) == 0:
+                    msg = 'No profiles found, cannot ' +\
+                        'generate facial expression animation.'
+                    self.logger.error(msg)
+                    raise ValueError(msg)
+                default_key = next(iter(self.profiles))
+                postprocess_names = self.profiles[default_key]
+                self.logger.warning(
+                    f'Profile {profile_name} not found, ' +
+                    f'using default profile {default_key}')
             old_pcm_bytes = \
                 self.request_space[chunk_body.request_id]['pcm_bytes']
             last_split_time = \

--- a/configs/cpu.py
+++ b/configs/cpu.py
@@ -12,6 +12,14 @@ __logger_cfg__ = dict(
     logger_path="logs/server.log"
 )
 __fps__ = 30
+__default_profile__ = [
+    'unitalker_clip',
+    'arkit_to_mmd',
+    'mmd_jaw_open_blend',
+    'mouth_scale',
+    'mmd_offset',
+    'mmd_emotional_blink'
+]
 response_chunk_n_frames = 10
 max_workers = 4
 enable_cors = True
@@ -21,35 +29,12 @@ logger_cfg = __logger_cfg__
 python_api_cfg = dict(
     type='StreamingAudio2FaceV1',
     profiles={
-        'KQ-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-        'Ani-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-        'HT-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-        'FNN-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-
+        'KQ-default': __default_profile__,
+        'Ani-default': __default_profile__,
+        'HT-default': __default_profile__,
+        'FNN-default': __default_profile__,
+        'KL-default': __default_profile__,
+        'NXD-default': __default_profile__
     },
     feature_extractor_cfg=dict(
         type='TorchFeatureExtractor',

--- a/configs/cuda.py
+++ b/configs/cuda.py
@@ -12,6 +12,14 @@ __logger_cfg__ = dict(
     logger_path="logs/server.log"
 )
 __fps__ = 30
+__default_profile__ = [
+    'unitalker_clip',
+    'arkit_to_mmd',
+    'mmd_jaw_open_blend',
+    'mouth_scale',
+    'mmd_offset',
+    'mmd_emotional_blink'
+]
 response_chunk_n_frames = 10
 max_workers = 4
 enable_cors = True
@@ -21,35 +29,12 @@ logger_cfg = __logger_cfg__
 python_api_cfg = dict(
     type='StreamingAudio2FaceV1',
     profiles={
-        'KQ-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-        'Ani-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-        'HT-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-        'FNN-default': [
-            'unitalker_clip',
-            'arkit_to_mmd',
-            'mmd_jaw_open_blend',
-            'mouth_scale',
-            'mmd_offset',
-            'mmd_emotional_blink'],
-
+        'KQ-default': __default_profile__,
+        'Ani-default': __default_profile__,
+        'HT-default': __default_profile__,
+        'FNN-default': __default_profile__,
+        'KL-default': __default_profile__,
+        'NXD-default': __default_profile__
     },
     feature_extractor_cfg=dict(
         type='TorchFeatureExtractor',


### PR DESCRIPTION
## Summary

This PR adds a fallback mechanism for handling missing profiles in the streaming audio2face API and refactors the configuration files to reduce code duplication. The changes improve robustness by gracefully handling cases where a requested profile doesn't exist, and simplify maintenance by extracting common profile configurations.

## Changes

- **audio2face/apis/streaming_audio2face_v1.py**: Added profile fallback logic that uses a default profile when the requested profile is not found. If no profiles exist at all, an error is raised. This logic is applied in both \`chunk_body\` and \`chunk_end\` processing methods.
- **configs/cpu.py**: Extracted repeated profile configuration into \`__default_profile__\` variable and added two new profiles (\`KL-default\` and \`NXD-default\`).
- **configs/cuda.py**: Applied the same refactoring as cpu.py - extracted common profile configuration and added \`KL-default\` and \`NXD-default\` profiles.

## Additional Notes

- The fallback mechanism logs a warning when using a default profile instead of the requested one, which helps with debugging and monitoring.
- The refactoring reduces code duplication and makes it easier to add new profiles or modify the default profile configuration in the future.